### PR TITLE
Adding chmod to make SSH happy about permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ NAME        LABELS    STATUS
 ## Logging In
 
 ```
+$ chmod 600 files/kubestack_id_rsa
 $ ssh -i files/kubestack_id_rsa core@$vm-ip-address
 ```


### PR DESCRIPTION
Fixes this:
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for 'files/kubestack_id_rsa' are too open.
